### PR TITLE
Update python_ex287.py

### DIFF
--- a/python_ex287.py
+++ b/python_ex287.py
@@ -9,4 +9,4 @@ def index():
     return "Hello, World!"
 
 
-app.run(port='8000')
+app.run(port=8000)


### PR DESCRIPTION
TypeError: port must be an integer